### PR TITLE
Fix code formatting

### DIFF
--- a/docs/HOWTO-Treemap.md
+++ b/docs/HOWTO-Treemap.md
@@ -1303,7 +1303,8 @@ Instead of using randomly generated colors, you can apply a
 style sheet to control colors in the SVG version: 
 
 ```commandline
- python3 treemap.py data/Howto-examples/majors-23F.json --css data/Howto-examples/UO-majors-colors.css 1024 768```
+python3 treemap.py data/Howto-examples/majors-23F.json --css data/Howto-examples/UO-majors-colors.css 1024 768
+```
 
 ![Declared majors in an intro CS course](img/majors-23F.png)
 


### PR DESCRIPTION
Near the end of the file, the closing triple-backtick delimiter on one of the code blocks was not shunted to the next line, which was causing markdown parsing to fail and render the remaining portion of the document as a code block.

This pull request basically just moves the closing delimiter of the code block to the next line to make sure that everything renders correctly. It also places the command flush with the first column, but that's the less important change for sure.